### PR TITLE
add 3.7 to the list

### DIFF
--- a/stdlib_list/base.py
+++ b/stdlib_list/base.py
@@ -7,7 +7,7 @@ base_dir = os.path.dirname(os.path.realpath(__file__))
 
 list_dir = os.path.join(base_dir, "lists")
 
-long_versions = ["2.6.9", "2.7.9", "3.2.6", "3.3.6", "3.4.3", "3.5", "3.6"]
+long_versions = ["2.6.9", "2.7.9", "3.2.6", "3.3.6", "3.4.3", "3.5", "3.6", "3.7"]
 
 short_versions = [".".join(x.split(".")[:2]) for x in long_versions]
 


### PR DESCRIPTION
Last change to add `Python 3.7` support.